### PR TITLE
Update Rocket.php - Correct forget $ before var

### DIFF
--- a/Rocket.php
+++ b/Rocket.php
@@ -190,7 +190,7 @@ class RocketPlugin extends MantisPlugin {
 
     function get_text_attachment($text) {
         $attachment = array('color' => '#3AA3E3', 'mrkdwn_in' => array('pretext', 'text', 'fields'));
-        $attachment['fallback'] = text . "\n";
+        $attachment['fallback'] = $text . "\n";
         $attachment['text'] = $text;
         return $attachment;
     }


### PR DESCRIPTION
In my case, bug notification : 
`
2023/07/21 11:18:58 [error] 522#522: *44958 FastCGI sent in stderr: "PHP message: Undefined constant "text"
/var/www/html/mantisbt/plugins/Rocket/Rocket.php: 198: RocketPlugin - -> - get_text_attachment()
/var/www/html/mantisbt/core/event_api.php: 206: RocketPlugin - -> - bugnote_add_edit()
/var/www/html/mantisbt/core/event_api.php: 232: - - - - event_callback()
/var/www/html/mantisbt/core/event_api.php: 164: - - - - event_type_execute()
/var/www/html/mantisbt/core/commands/IssueNoteAddCommand.php: 281: - - - - event_signal()
/var/www/html/mantisbt/core/commands/Command.php: 137: IssueNoteAddCommand - -> - process()
`
